### PR TITLE
IDEA-253543: Include annotations in ChangeParametersRequest

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/ChangeMethodParameters.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/crossLanguage/ChangeMethodParameters.kt
@@ -149,7 +149,7 @@ internal class ChangeMethodParameters(
             when (action) {
                 is ParameterModification.Add -> {
                     val parameter = parametersGenerated.getValue(action)
-                    for (expectedAnnotation in action.expectedAnnotations) {
+                    for (expectedAnnotation in action.expectedAnnotations.reversed()) {
                         addAnnotationEntry(parameter, expectedAnnotation, null)
                     }
                     val anchor = action.beforeAnchor


### PR DESCRIPTION
This PR is the Kotlin plugin counterpart of JetBrains/intellij-community#1463.

Unfortunately class literals can't be preserved because `PsiAnnotationClassValue#getReferenceElement` returns null. I dug a bit into the code and found that it happens because Kotlin provides a `LightTypeElement` in `KtLightPsiClassObjectAccessExpression#getOperand`, which always returns a null reference element.

Issue link: <https://youtrack.jetbrains.com/issue/IDEA-253543>