### PR TITLE
KTIJ-565 False positive "Redundant semicolon" before empty lambda return value

### DIFF
--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -8410,6 +8410,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         public void testStartOfLine2() throws Exception {
             runTest("testData/inspectionsLocal/redundantSemicolon/startOfLine2.kt");
         }
+
+        @TestMetadata("startOfLineBeforeLambda.kt")
+        public void testStartOfLineBeforeLambda() throws Exception {
+            runTest("testData/inspectionsLocal/redundantSemicolon/startOfLineBeforeLambda.kt");
+        }
     }
 
     @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/testData/inspectionsLocal/redundantSemicolon/startOfLineBeforeLambda.kt
+++ b/idea/testData/inspectionsLocal/redundantSemicolon/startOfLineBeforeLambda.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+fun foo(): () -> Unit = if (true) {
+    {}
+} else {
+    bar()
+    <caret>;{}
+}
+
+fun bar() {}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-565