### PR TITLE
KT-43965 "Convert `forEach` call to `onEach`" for scope function with nested `forEach` and a function reference inside doesn't insert brackets

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyNestedEachInScopeFunctionInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyNestedEachInScopeFunctionInspection.kt
@@ -232,7 +232,7 @@ class SimplifyNestedEachInScopeFunctionInspection : AbstractKotlinInspection() {
                 innerBlock.accept(ReplaceLabelVisitor(factory))
             }
             val innerBlockExpression = innerBlock.getArgumentExpression()
-            if (innerBlockExpression is KtCallableReferenceExpression) {
+            if (innerBlockExpression != null && KtPsiUtil.deparenthesize(innerBlockExpression) is KtCallableReferenceExpression) {
                 callExpression.replace(factory.createExpressionByPattern("onEach($0)", innerBlockExpression))
             } else {
                 outerBlock.replace(innerBlock)

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyNestedEachInScopeFunctionInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/SimplifyNestedEachInScopeFunctionInspection.kt
@@ -228,10 +228,16 @@ class SimplifyNestedEachInScopeFunctionInspection : AbstractKotlinInspection() {
             }
             val factory = KtPsiFactory(project)
             val innerBlock = eachCall.valueArguments.singleOrNull() ?: return
-            if (label?.labelQualifier == null && eachCall.calleeExpression?.text == "forEach")
+            if (label?.labelQualifier == null && eachCall.calleeExpression?.text == "forEach") {
                 innerBlock.accept(ReplaceLabelVisitor(factory))
-            outerBlock.replace(innerBlock)
-            descriptor.psiElement.replace(factory.createExpression("onEach"))
+            }
+            val innerBlockExpression = innerBlock.getArgumentExpression()
+            if (innerBlockExpression is KtCallableReferenceExpression) {
+                callExpression.replace(factory.createExpressionByPattern("onEach($0)", innerBlockExpression))
+            } else {
+                outerBlock.replace(innerBlock)
+                descriptor.psiElement.replace(factory.createExpression("onEach"))
+            }
         }
     }
 }

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -12668,6 +12668,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/simplifyNestedEachInScope/also5.kt");
         }
 
+        @TestMetadata("alsoFunctionReference.kt")
+        public void testAlsoFunctionReference() throws Exception {
+            runTest("testData/inspectionsLocal/simplifyNestedEachInScope/alsoFunctionReference.kt");
+        }
+
         @TestMetadata("alsoLabel.kt")
         public void testAlsoLabel() throws Exception {
             runTest("testData/inspectionsLocal/simplifyNestedEachInScope/alsoLabel.kt");
@@ -12696,6 +12701,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
         @TestMetadata("apply3.kt")
         public void testApply3() throws Exception {
             runTest("testData/inspectionsLocal/simplifyNestedEachInScope/apply3.kt");
+        }
+
+        @TestMetadata("applyFunctionReference.kt")
+        public void testApplyFunctionReference() throws Exception {
+            runTest("testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt");
         }
 
         @TestMetadata("applyLabel.kt")

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -12708,6 +12708,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt");
         }
 
+        @TestMetadata("applyFunctionReferenceWithParentheses.kt")
+        public void testApplyFunctionReferenceWithParentheses() throws Exception {
+            runTest("testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReferenceWithParentheses.kt");
+        }
+
         @TestMetadata("applyLabel.kt")
         public void testApplyLabel() throws Exception {
             runTest("testData/inspectionsLocal/simplifyNestedEachInScope/applyLabel.kt");

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/alsoFunctionReference.kt
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/alsoFunctionReference.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).<caret>also { it.forEach(::foo) }.filter { it > 1 }
+}

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/alsoFunctionReference.kt.after
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/alsoFunctionReference.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).onEach(::foo).filter { it > 1 }
+}

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).<caret>apply { forEach(::foo) }.filter { it > 1 }
+}

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt.after
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReference.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).onEach(::foo).filter { it > 1 }
+}

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReferenceWithParentheses.kt
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReferenceWithParentheses.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).<caret>apply { forEach((::foo)) }.filter { it > 1 }
+}

--- a/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReferenceWithParentheses.kt.after
+++ b/idea/testData/inspectionsLocal/simplifyNestedEachInScope/applyFunctionReferenceWithParentheses.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+fun foo(num: Int) = println(num + 1)
+
+fun test(): List<Int> {
+    return listOf(1, 2, 3).onEach((::foo)).filter { it > 1 }
+}


### PR DESCRIPTION
Issue link: https://youtrack.jetbrains.com/issue/KT-43965