### PR TITLE
KTIJ-482 False positive "Unused symbol" for class, with inner class, type parameter with upper bound

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/UnusedSymbolInspection.kt
@@ -364,7 +364,7 @@ class UnusedSymbolInspection : AbstractKotlinInspection() {
                         val callableDeclaration = parameter.getStrictParentOfType<KtCallableDeclaration>()?.let {
                             if (it !is KtNamedFunction) it.containingClass() else it
                         } ?: return@any false
-                        val typeParameters = callableDeclaration.typeParameters.map { it.text }
+                        val typeParameters = callableDeclaration.typeParameters.map { it.name }
                         if (typeParameters.isEmpty()) return@any false
                         if (typeArguments.none { it.text in typeParameters }) return@any false
 

--- a/idea/testData/inspections/unusedSymbol/typeParameter/usedClassTypeParameter.kt
+++ b/idea/testData/inspections/unusedSymbol/typeParameter/usedClassTypeParameter.kt
@@ -22,8 +22,19 @@ fun <U> foo3(foo: UsedClassTypeParameter3<U>) {
     println(foo)
 }
 
+open class AnotherClass
+class UsedClassTypeParameter4<T: AnotherClass> {
+    fun foo() = InnerClass(this)
+    class InnerClass<T: AnotherClass>(outerClass: UsedClassTypeParameter4<T>) {
+        init {
+            println(outerClass)
+        }
+    }
+}
+
 fun main(args: Array<String>) {
     UsedClassTypeParameter("")
     UsedClassTypeParameter2<Int>().test()
     foo3(UsedClassTypeParameter3<Int>())
+    UsedClassTypeParameter4<AnotherClass>().foo()
 }


### PR DESCRIPTION
Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-482>