### PR TITLE
Ignore diagnostics in ShadowedDeclarationsFilter

### DIFF
--- a/common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt
+++ b/common/src/org/jetbrains/kotlin/idea/util/ShadowedDeclarationsFilter.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.idea.resolve.getDataFlowValueFactory
 import org.jetbrains.kotlin.idea.resolve.getLanguageVersionSettings
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.BindingTraceFilter.Companion.NO_DIAGNOSTICS
 import org.jetbrains.kotlin.resolve.DelegatingBindingTrace
 import org.jetbrains.kotlin.resolve.bindingContextUtil.getDataFlowInfoBefore
 import org.jetbrains.kotlin.resolve.calls.CallResolver
@@ -121,7 +122,10 @@ class ShadowedDeclarationsFilter(
 
         val dummyArgumentExpressions = dummyExpressionFactory.createDummyExpressions(parameters.size)
 
-        val bindingTrace = DelegatingBindingTrace(bindingContext, "Temporary trace for filtering shadowed declarations")
+        val bindingTrace = DelegatingBindingTrace(
+            bindingContext, "Temporary trace for filtering shadowed declarations",
+            filter = NO_DIAGNOSTICS
+        )
         for ((expression, parameter) in dummyArgumentExpressions.zip(parameters)) {
             bindingTrace.recordType(expression, parameter.varargElementType ?: parameter.type)
             bindingTrace.record(BindingContext.PROCESSED, expression, true)


### PR DESCRIPTION
During code completion, ShadowedDeclarationsFilter resolves many
synthetic calls (sometimes >1000 for certain projects/scenarios).
By ignoring diagnostics we can avoid running call checkers
during this process (pending a sibling change in the compiler).

Relates to KT-44276 and github.com/JetBrains/kotlin/pull/4027.

Issue link: https://youtrack.jetbrains.com/issue/KT-44276

cc @vladimirdolzhenko; let me know what you think