### PR TITLE
KTIJ-552 Inspection 'Join declaration and assignment' used on fields initialized in secondary constructor produces uncompilable code

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/JoinDeclarationAndAssignmentIntention.kt
@@ -144,7 +144,7 @@ class JoinDeclarationAndAssignmentIntention : SelfTargetingRangeIntention<KtProp
         if (assignments.any { it !== firstAssignment && it.parent.parent is KtSecondaryConstructor }) return null
         if (!property.isLocal &&
             firstAssignment.parent != propertyContainer &&
-            firstAssignment.right.safeAs<KtNameReferenceExpression>()?.mainReference?.resolve() is KtParameter
+            firstAssignment.right?.anyDescendantOfType<KtNameReferenceExpression> { it.mainReference.resolve() is KtParameter } == true
         ) return null
 
         val context = firstAssignment.analyze()

--- a/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -10683,6 +10683,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/joinDeclarationAndAssignment/notFirstSecondaryConstructorLine.kt");
         }
 
+        @TestMetadata("propertyAssignmentWithConstructorParameter.kt")
+        public void testPropertyAssignmentWithConstructorParameter() throws Exception {
+            runTest("testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter.kt");
+        }
+
         @TestMetadata("propertyReassignment.kt")
         public void testPropertyReassignment() throws Exception {
             runTest("testData/intentions/joinDeclarationAndAssignment/propertyReassignment.kt");

--- a/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -10688,6 +10688,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter.kt");
         }
 
+        @TestMetadata("propertyAssignmentWithConstructorParameter2.kt")
+        public void testPropertyAssignmentWithConstructorParameter2() throws Exception {
+            runTest("testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter2.kt");
+        }
+
         @TestMetadata("propertyReassignment.kt")
         public void testPropertyReassignment() throws Exception {
             runTest("testData/intentions/joinDeclarationAndAssignment/propertyReassignment.kt");

--- a/idea/testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter.kt
+++ b/idea/testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter.kt
@@ -1,0 +1,10 @@
+// IS_APPLICABLE: false
+class Id {
+    val id: Int<caret>
+
+    constructor(id: Int) {
+        this.id = id
+    }
+
+    constructor() : this(0)
+}

--- a/idea/testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter2.kt
+++ b/idea/testData/intentions/joinDeclarationAndAssignment/propertyAssignmentWithConstructorParameter2.kt
@@ -1,0 +1,10 @@
+// IS_APPLICABLE: false
+class Id {
+    val id: Int<caret>
+
+    constructor(id: Int) {
+        this.id = id + 1
+    }
+
+    constructor() : this(0)
+}


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-552>