### PR TITLE
KT-43826 "Add `constructor` keyword" inserts keyword to the wrong location if there are open-close parenthesis and annotation

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/util/quickfixUtil.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/util/quickfixUtil.kt
@@ -47,8 +47,14 @@ fun createIntentionFactory(
 }
 
 fun KtPrimaryConstructor.addConstructorKeyword(): PsiElement? {
-    val keyword = KtPsiFactory(this).createConstructorKeyword()
-    return addAfter(keyword, modifierList ?: return null)
+    val modifierList = this.modifierList ?:  return null
+    val psiFactory = KtPsiFactory(this)
+    val constructor = if (valueParameterList == null) {
+        psiFactory.createPrimaryConstructor("constructor()")
+    } else {
+        psiFactory.createConstructorKeyword()
+    }
+    return addAfter(constructor, modifierList)
 }
 
 fun getDataFlowAwareTypes(

--- a/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -8347,6 +8347,16 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             public void testBasic() throws Exception {
                 runTest("testData/quickfix/migration/missingConstructorKeyword/basic.kt");
             }
+
+            @TestMetadata("noParentheses.kt")
+            public void testNoParentheses() throws Exception {
+                runTest("testData/quickfix/migration/missingConstructorKeyword/noParentheses.kt");
+            }
+
+            @TestMetadata("noParenthesesWithAnnotation.kt")
+            public void testNoParenthesesWithAnnotation() throws Exception {
+                runTest("testData/quickfix/migration/missingConstructorKeyword/noParenthesesWithAnnotation.kt");
+            }
         }
 
         @RunWith(JUnit3RunnerWithInners.class)

--- a/idea/testData/quickfix/migration/missingConstructorKeyword/noParentheses.kt
+++ b/idea/testData/quickfix/migration/missingConstructorKeyword/noParentheses.kt
@@ -1,0 +1,3 @@
+// "Add 'constructor' keyword" "true"
+class A private<caret> {
+}

--- a/idea/testData/quickfix/migration/missingConstructorKeyword/noParentheses.kt.after
+++ b/idea/testData/quickfix/migration/missingConstructorKeyword/noParentheses.kt.after
@@ -1,0 +1,3 @@
+// "Add 'constructor' keyword" "true"
+class A private constructor() {
+}

--- a/idea/testData/quickfix/migration/missingConstructorKeyword/noParenthesesWithAnnotation.kt
+++ b/idea/testData/quickfix/migration/missingConstructorKeyword/noParenthesesWithAnnotation.kt
@@ -1,0 +1,5 @@
+// "Add 'constructor' keyword" "true"
+annotation class Ann
+
+class A @Ann()<caret> {
+}

--- a/idea/testData/quickfix/migration/missingConstructorKeyword/noParenthesesWithAnnotation.kt.after
+++ b/idea/testData/quickfix/migration/missingConstructorKeyword/noParenthesesWithAnnotation.kt.after
@@ -1,0 +1,5 @@
+// "Add 'constructor' keyword" "true"
+annotation class Ann
+
+class A @Ann() constructor() {
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KT-43826>