### PR TITLE
KTIJ-995 "Add 1st parameter" quickfix isn't suggested if lambda argument is out of parentheses

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/AddFunctionParametersFix.kt
@@ -230,7 +230,7 @@ class AddFunctionParametersFix(
 
         override fun extractFixData(element: KtCallElement, diagnostic: Diagnostic): Pair<FunctionDescriptor, Int>? {
             val (valueArgument, valueArgumentList) = diagnostic.valueArgument() ?: return null
-            val arguments = valueArgumentList.arguments
+            val arguments = valueArgumentList.arguments + element.lambdaArguments
             val argumentIndex = arguments.indexOfFirst { it == valueArgument }
             val context = element.analyze()
             val functionDescriptor = element.getResolvedCall(context)?.resultingDescriptor as? FunctionDescriptor ?: return null

--- a/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -2174,6 +2174,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/changeSignature/addFunctionParameterForTypeMismatch5.kt");
         }
 
+        @TestMetadata("addFunctionParameterForTypeMismatchWithLambdaArgument.kt")
+        public void testAddFunctionParameterForTypeMismatchWithLambdaArgument() throws Exception {
+            runTest("testData/quickfix/changeSignature/addFunctionParameterForTypeMismatchWithLambdaArgument.kt");
+        }
+
         @TestMetadata("addFunctionParameterLongNameRuntime.kt")
         public void testAddFunctionParameterLongNameRuntime() throws Exception {
             runTest("testData/quickfix/changeSignature/addFunctionParameterLongNameRuntime.kt");

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatchWithLambdaArgument.kt
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatchWithLambdaArgument.kt
@@ -1,0 +1,6 @@
+// "Add 1st parameter to function 'foo'" "true"
+fun foo(f: () -> Unit) {}
+
+fun test() {
+    foo(""<caret>) {}
+}

--- a/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatchWithLambdaArgument.kt.after
+++ b/idea/testData/quickfix/changeSignature/addFunctionParameterForTypeMismatchWithLambdaArgument.kt.after
@@ -1,0 +1,6 @@
+// "Add 1st parameter to function 'foo'" "true"
+fun foo(f1: String, f: () -> Unit) {}
+
+fun test() {
+    foo("") {}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-995>