### PR TITLE
KTIJ-583 `Convert property initializer to getter` intention does not add imports

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyInitializerToGetterIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/ConvertPropertyInitializerToGetterIntention.kt
@@ -48,11 +48,6 @@ class ConvertPropertyInitializerToGetterIntention : SelfTargetingRangeIntention<
         }
 
         fun convertPropertyInitializerToGetter(property: KtProperty, editor: Editor?) {
-            val type = SpecifyTypeExplicitlyIntention.getTypeForDeclaration(property)
-            if (!type.isError) {
-                SpecifyTypeExplicitlyIntention.addTypeAnnotation(editor, property, type)
-            }
-
             val initializer = property.initializer!!
             val getter = KtPsiFactory(property).createPropertyGetter(initializer)
             val setter = property.setter
@@ -69,6 +64,11 @@ class ConvertPropertyInitializerToGetterIntention : SelfTargetingRangeIntention<
             }
 
             property.initializer = null
+
+            val type = SpecifyTypeExplicitlyIntention.getTypeForDeclaration(property)
+            if (!type.isError) {
+                SpecifyTypeExplicitlyIntention.addTypeAnnotation(editor, property, type)
+            }
         }
     }
 }

--- a/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -6110,6 +6110,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/convertPropertyInitializerToGetter/onPropertyName.kt");
         }
 
+        @TestMetadata("otherPackageType.kt")
+        public void testOtherPackageType() throws Exception {
+            runTest("testData/intentions/convertPropertyInitializerToGetter/otherPackageType.kt");
+        }
+
         @TestMetadata("propertyWithInitializerWithSetter.kt")
         public void testPropertyWithInitializerWithSetter() throws Exception {
             runTest("testData/intentions/convertPropertyInitializerToGetter/propertyWithInitializerWithSetter.kt");

--- a/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.1.kt
+++ b/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.1.kt
@@ -1,0 +1,7 @@
+package foo
+
+class Foo
+
+class Bar {
+    fun foo() = Foo()
+}

--- a/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.1.kt.after
+++ b/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.1.kt.after
@@ -1,0 +1,7 @@
+package foo
+
+class Foo
+
+class Bar {
+    fun foo() = Foo()
+}

--- a/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.kt
+++ b/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.kt
@@ -1,0 +1,5 @@
+import foo.Bar
+
+class Test {
+    val <caret>foo = Bar().foo()
+}

--- a/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.kt.after
+++ b/idea/testData/intentions/convertPropertyInitializerToGetter/otherPackageType.kt.after
@@ -1,0 +1,7 @@
+import foo.Bar
+import foo.Foo
+
+class Test {
+    val foo: Foo
+        get() = Bar().foo()
+}


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-583>