### PR TITLE
KTIJ-1007 "Wrap with '?.let { ... } call'" quick fix produces incorrect result for expression with Elvis operator

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithSafeLetCallFix.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/quickfix/WrapWithSafeLetCallFix.kt
@@ -73,10 +73,14 @@ class WrapWithSafeLetCallFix(
             else -> element
         }
         val wrapped = when (name) {
-            "it" -> factory.createExpressionByPattern("$0?.let { $1 }", nullableText, underLetExpression)
-            else -> factory.createExpressionByPattern("$0?.let { $1 -> $2 }", nullableText, name, underLetExpression)
+            "it" -> factory.createExpressionByPattern("($0)?.let { $1 }", nullableText, underLetExpression)
+            else -> factory.createExpressionByPattern("($0)?.let { $1 -> $2 }", nullableText, name, underLetExpression)
         }
-        (qualifiedExpression ?: element).replace(wrapped)
+        val replaced = (qualifiedExpression ?: element).replace(wrapped) as KtSafeQualifiedExpression
+        val receiver = replaced.receiverExpression
+        if (receiver is KtParenthesizedExpression && KtPsiUtil.areParenthesesUseless(receiver)) {
+            receiver.replace(KtPsiUtil.safeDeparenthesize(receiver))
+        }
     }
 
     object UnsafeFactory : KotlinSingleIntentionActionFactory() {

--- a/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/quickfix/QuickFixTestGenerated.java
@@ -14302,6 +14302,11 @@ public abstract class QuickFixTestGenerated extends AbstractQuickFixTest {
             runTest("testData/quickfix/wrapWithSafeLetCall/chainedUnsafeCall.kt");
         }
 
+        @TestMetadata("elvisArgument.kt")
+        public void testElvisArgument() throws Exception {
+            runTest("testData/quickfix/wrapWithSafeLetCall/elvisArgument.kt");
+        }
+
         @TestMetadata("expressionUnsafeCall.kt")
         public void testExpressionUnsafeCall() throws Exception {
             runTest("testData/quickfix/wrapWithSafeLetCall/expressionUnsafeCall.kt");

--- a/idea/testData/quickfix/wrapWithSafeLetCall/elvisArgument.kt
+++ b/idea/testData/quickfix/wrapWithSafeLetCall/elvisArgument.kt
@@ -1,0 +1,7 @@
+// "Wrap with '?.let { ... }' call" "true"
+// WITH_RUNTIME
+fun foo(i: Int) {}
+
+fun test(a: Int?, b: Int?) {
+    foo(<caret>a ?: b)
+}

--- a/idea/testData/quickfix/wrapWithSafeLetCall/elvisArgument.kt.after
+++ b/idea/testData/quickfix/wrapWithSafeLetCall/elvisArgument.kt.after
@@ -1,0 +1,7 @@
+// "Wrap with '?.let { ... }' call" "true"
+// WITH_RUNTIME
+fun foo(i: Int) {}
+
+fun test(a: Int?, b: Int?) {
+    (a ?: b)?.let { foo(it) }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-1007>