### PR TITLE
KTIJ-1086 `Replace 'isEmpty' with 'ifEmpty'` quickfix breaks code in case it is performed in a loop with `continue` or `break`

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceIsEmptyWithIfEmptyInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceIsEmptyWithIfEmptyInspection.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.idea.KotlinBundle
 import org.jetbrains.kotlin.idea.caches.resolve.analyze
 import org.jetbrains.kotlin.idea.intentions.branchedTransformations.isElseIf
+import org.jetbrains.kotlin.idea.intentions.loopToCallChain.targetLoop
 import org.jetbrains.kotlin.idea.project.languageVersionSettings
 import org.jetbrains.kotlin.idea.util.textRangeIn
 import org.jetbrains.kotlin.name.FqName
@@ -81,7 +82,7 @@ class ReplaceIsEmptyWithIfEmptyInspection : AbstractKotlinInspection() {
         if (loop != null) {
             val defaultValueExpression = (if (replacement.negativeCondition) elseExpression else thenExpression)
             if (defaultValueExpression.anyDescendantOfType<KtExpression> {
-                    (it is KtContinueExpression || it is KtBreakExpression) && it.getStrictParentOfType<KtLoopExpression>() == loop
+                    (it is KtContinueExpression || it is KtBreakExpression) && (it as KtExpressionWithLabel).targetLoop(context) == loop
                 }
             ) return
         }

--- a/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/loopToCallChain/commonUtils.kt
@@ -120,13 +120,13 @@ fun KtCallableDeclaration.hasDifferentSetsOfUsages(elements1: Collection<KtEleme
     return countUsages(elements1 - elements2) != countUsages(elements2 - elements1)
 }
 
-fun KtExpressionWithLabel.targetLoop(): KtLoopExpression? {
+fun KtExpressionWithLabel.targetLoop(context: BindingContext? = null): KtLoopExpression? {
     val label = getTargetLabel()
     return if (label == null) {
         parents.firstIsInstance<KtLoopExpression>()
     } else {
         //TODO: does PARTIAL always work here?
-        analyze(BodyResolveMode.PARTIAL)[BindingContext.LABEL_TARGET, label] as? KtLoopExpression
+        (context ?: analyze(BodyResolveMode.PARTIAL))[BindingContext.LABEL_TARGET, label] as? KtLoopExpression
     }
 }
 

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10556,6 +10556,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue.kt");
         }
 
+        @TestMetadata("defaultValueBlockHasLabeledBreak.kt")
+        public void testDefaultValueBlockHasLabeledBreak() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak.kt");
+        }
+
+        @TestMetadata("defaultValueBlockHasLabeledContinue.kt")
+        public void testDefaultValueBlockHasLabeledContinue() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue.kt");
+        }
+
         @TestMetadata("defaultValueBlockHasMultiStatement.kt")
         public void testDefaultValueBlockHasMultiStatement() throws Exception {
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasMultiStatement.kt");

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10551,9 +10551,19 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak.kt");
         }
 
+        @TestMetadata("defaultValueBlockHasBreak2.kt")
+        public void testDefaultValueBlockHasBreak2() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak2.kt");
+        }
+
         @TestMetadata("defaultValueBlockHasContinue.kt")
         public void testDefaultValueBlockHasContinue() throws Exception {
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue.kt");
+        }
+
+        @TestMetadata("defaultValueBlockHasContinue2.kt")
+        public void testDefaultValueBlockHasContinue2() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue2.kt");
         }
 
         @TestMetadata("defaultValueBlockHasLabeledBreak.kt")
@@ -10561,9 +10571,19 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak.kt");
         }
 
+        @TestMetadata("defaultValueBlockHasLabeledBreak2.kt")
+        public void testDefaultValueBlockHasLabeledBreak2() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak2.kt");
+        }
+
         @TestMetadata("defaultValueBlockHasLabeledContinue.kt")
         public void testDefaultValueBlockHasLabeledContinue() throws Exception {
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue.kt");
+        }
+
+        @TestMetadata("defaultValueBlockHasLabeledContinue2.kt")
+        public void testDefaultValueBlockHasLabeledContinue2() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue2.kt");
         }
 
         @TestMetadata("defaultValueBlockHasMultiStatement.kt")

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -10546,6 +10546,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
         }
 
+        @TestMetadata("defaultValueBlockHasBreak.kt")
+        public void testDefaultValueBlockHasBreak() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak.kt");
+        }
+
+        @TestMetadata("defaultValueBlockHasContinue.kt")
+        public void testDefaultValueBlockHasContinue() throws Exception {
+            runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue.kt");
+        }
+
         @TestMetadata("defaultValueBlockHasMultiStatement.kt")
         public void testDefaultValueBlockHasMultiStatement() throws Exception {
             runTest("testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasMultiStatement.kt");

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = if (listOne.isNotEmpty<caret>()) {
+            listOne
+        } else {
+            listOf(listTwo.firstOrNull() ?: break)
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak2.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak2.kt
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = if (listOne.isNotEmpty<caret>()) {
+            listOne
+        } else {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: break)
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak2.kt.after
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasBreak2.kt.after
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = listOne.ifEmpty {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: break)
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = if (listOne.isEmpty<caret>()) {
+            listOf(listTwo.firstOrNull() ?: continue)
+        } else {
+            listOne
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue2.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue2.kt
@@ -1,0 +1,12 @@
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = if (listOne.isEmpty<caret>()) {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: continue)
+            }
+        } else {
+            listOne
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue2.kt.after
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasContinue2.kt.after
@@ -1,0 +1,10 @@
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    for (i in 1..10) {
+        val z = listOne.ifEmpty {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: continue)
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    outer@ for (i in 1..10) {
+        val z = if (listOne.isNotEmpty<caret>()) {
+            listOne
+        } else {
+            listOf(listTwo.firstOrNull() ?: break@outer)
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak2.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledBreak2.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    outer@ for (i in 1..10) {
+        val z = if (listOne.isNotEmpty<caret>()) {
+            listOne
+        } else {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: break@outer)
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue.kt
@@ -1,0 +1,11 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    outer@ for (i in 1..10) {
+        val z = if (listOne.isEmpty<caret>()) {
+            listOf(listTwo.firstOrNull() ?: continue@outer)
+        } else {
+            listOne
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue2.kt
+++ b/idea/testData/inspectionsLocal/replaceIsEmptyWithIfEmpty/defaultValueBlockHasLabeledContinue2.kt
@@ -1,0 +1,13 @@
+// PROBLEM: none
+// WITH_RUNTIME
+fun test(listOne: List<String>, listTwo: List<String>) {
+    outer@ for (i in 1..10) {
+        val z = if (listOne.isEmpty<caret>()) {
+            while (true) {
+                listOf(listTwo.firstOrNull() ?: continue@outer)
+            }
+        } else {
+            listOne
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/KTIJ-1086>