### PR TITLE
Fix performance of getModulesWithKotlinFiles

### DIFF
--- a/jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInProjectUtils.kt
+++ b/jvm/src/org/jetbrains/kotlin/idea/configuration/ConfigureKotlinInProjectUtils.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.projectRoots.JavaSdkVersion
 import com.intellij.openapi.roots.DependencyScope
 import com.intellij.openapi.roots.LibraryOrderEntry
 import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.roots.impl.libraries.LibraryEx
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind
 import com.intellij.openapi.util.Computable
@@ -24,11 +25,10 @@ import com.intellij.psi.PsiJavaModule
 import com.intellij.psi.search.DelegatingGlobalSearchScope
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
-import org.jetbrains.annotations.CalledInBackground
+import com.intellij.util.concurrency.annotations.RequiresBackgroundThread
 import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.idea.KotlinJvmBundle
-import org.jetbrains.kotlin.idea.actions.internal.refactoringTesting.readAction
 import org.jetbrains.kotlin.idea.core.util.getKotlinJvmRuntimeMarkerClass
 import org.jetbrains.kotlin.idea.framework.JSLibraryKind
 import org.jetbrains.kotlin.idea.framework.effectiveKind
@@ -43,6 +43,7 @@ import org.jetbrains.kotlin.idea.versions.SuppressNotificationState
 import org.jetbrains.kotlin.idea.versions.hasKotlinJsKjsmFile
 import org.jetbrains.kotlin.idea.vfilefinder.IDEVirtualFileFinder
 import org.jetbrains.kotlin.resolve.jvm.modules.KOTLIN_STDLIB_MODULE_NAME
+import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.kotlin.utils.ifEmpty
 
 private val LOG = Logger.getInstance("#org.jetbrains.kotlin.idea.configuration.ConfigureKotlinInProjectUtils")
@@ -130,26 +131,24 @@ fun isModuleConfigured(moduleSourceRootGroup: ModuleSourceRootGroup): Boolean {
  *
  * DO NOT CALL THIS ON AWT THREAD
  */
-@CalledInBackground
+@RequiresBackgroundThread
 fun getModulesWithKotlinFiles(project: Project): Collection<Module> {
     if (!isUnitTestMode() && ApplicationManager.getApplication().isDispatchThread) {
         LOG.error("getModulesWithKotlinFiles could be a heavy operation and should not be call on AWT thread")
     }
 
-    if (!project.runReadActionInSmartMode {
-            !project.isDisposed &&
-                    FileTypeIndex.containsFileOfType(KotlinFileType.INSTANCE, GlobalSearchScope.projectScope(project))
-        }) {
-        return emptyList()
-    }
-
-    return project.allModules()
-        .filter { module ->
-            project.runReadActionInSmartMode {
-                !project.isDisposed && !module.isDisposed
-                        && FileTypeIndex.containsFileOfType(KotlinFileType.INSTANCE, module.getModuleScope(true))
+    return project.runReadActionInSmartMode {
+        val projectFileIndex = ProjectFileIndex.getInstance(project)
+        val modules = mutableSetOf<Module>()
+        val ktFileProcessor = { ktFile: VirtualFile ->
+            if (projectFileIndex.isInSourceContent(ktFile)) {
+                modules.addIfNotNull(projectFileIndex.getModuleForFile(ktFile))
             }
+            true
         }
+        FileTypeIndex.processFiles(KotlinFileType.INSTANCE, ktFileProcessor, GlobalSearchScope.projectScope(project))
+        modules
+    }
 }
 
 /**


### PR DESCRIPTION
1. **Fix performance of getModulesWithKotlinFiles**
    
    In a project with 333 Kotlin modules, this reduces the cost
    from 10 seconds to 200 ms (50x faster).

    The main observations are:

    * Querying FileBasedIndex with module scope is roughly the same cost
      as querying it with project scope. So it is faster to do one query
      for the whole project than to do N queries for N modules.

    * Finding the module for a given VirtualFile is a cheap operation
      (roughly the same cost as ModuleWithDependenciesScope.contains).

    Relates to: [KT-40871](https://youtrack.jetbrains.com/issue/KT-40871), [KTIJ-249](https://youtrack.jetbrains.com/issue/KTIJ-249), KT-41936, KT-4809, etc.

2. **Cleanup in KotlinConfigurationCheckerService**
        
    * Revert to using getModulesWithKotlinFiles since it is fast now.

    * Make configuration non-cancelable, since presumably cancelation
      could result in misconfigured modules.

    Relates to: [KTIJ-249](https://youtrack.jetbrains.com/issue/KTIJ-249)

Note: the first commit is more important, but I think the second commit makes sense too.
Let me know what you think.