### PR TITLE
Add type parameters declared in typealias when building cls stubs

### DIFF
--- a/analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/typeAliasClsStubBuilding.kt
+++ b/analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/typeAliasClsStubBuilding.kt
@@ -21,9 +21,10 @@ fun createTypeAliasStub(
     parent: StubElement<out PsiElement>,
     typeAliasProto: ProtoBuf.TypeAlias,
     protoContainer: ProtoContainer,
-    context: ClsStubBuilderContext
+    outerContext: ClsStubBuilderContext
 ) {
-    val shortName = context.nameResolver.getName(typeAliasProto.name)
+    val c = outerContext.child(typeAliasProto.typeParameterList)
+    val shortName = c.nameResolver.getName(typeAliasProto.name)
 
     val classId = when (protoContainer) {
         is ProtoContainer.Class -> protoContainer.classId.createNestedClassId(shortName)
@@ -37,16 +38,16 @@ fun createTypeAliasStub(
 
     val modifierList = createModifierListStubForDeclaration(typeAlias, typeAliasProto.flags, arrayListOf(VISIBILITY), listOf())
 
-    val typeStubBuilder = TypeClsStubBuilder(context)
+    val typeStubBuilder = TypeClsStubBuilder(c)
     val restConstraints = typeStubBuilder.createTypeParameterListStub(typeAlias, typeAliasProto.typeParameterList)
     assert(restConstraints.isEmpty()) {
         "'where' constraints are not allowed for type aliases"
     }
 
     if (Flags.HAS_ANNOTATIONS.get(typeAliasProto.flags)) {
-        createAnnotationStubs(typeAliasProto.annotationList.map { context.nameResolver.getClassId(it.id) }, modifierList)
+        createAnnotationStubs(typeAliasProto.annotationList.map { c.nameResolver.getClassId(it.id) }, modifierList)
     }
 
-    val typeAliasUnderlyingType = typeAliasProto.underlyingType(context.typeTable)
+    val typeAliasUnderlyingType = typeAliasProto.underlyingType(c.typeTable)
     typeStubBuilder.createTypeReferenceStub(typeAlias, typeAliasUnderlyingType)
 }


### PR DESCRIPTION
This fixes an issue when some Kotlin class files, notably those produced
by kotlinx-metadata-jvm, would cause the cls stub builder to crash when
trying to build stubs for the type that references a type parameter
declared in a typealias.

The reason it doesn't fail for class files produced by the Kotlin
compiler is that the compiler uses another serialization scheme, where
type parameters are referenced by "name in the nearest container" when
possible (see
https://github.com/JetBrains/kotlin/blob/51da54ce669ae5ad0024ffc4ec329888dd8ff23b/core/metadata/src/metadata.proto#L148..L149),
and since typealias is always top level, it's always possible. Creating
a type parameter reference stub by name is easy and doesn't even require
that type parameter be declared anywhere, but just have its name present
in the string table, which is exactly what happens here (see
https://github.com/JetBrains/intellij-kotlin/blob/d7c0b8775ca04d92caeae95b539eb47090bdccb0/analysis/src/org/jetbrains/kotlin/idea/decompiler/stubBuilder/TypeClsStubBuilder.kt#L63).

kotlinx-metadata-jvm, on the other hand, always uses the other
serialization scheme where type parameters are referenced by a global
integer index, for simplicity. Reading such metadata requires keeping
track of all type parameters introduced in any declaration.
kotlinx-metadata-jvm does it correctly in all known cases. Cls stub
builder already did this for classes and callables, but didn't do for
type aliases, and this change fixes that.

Since kotlinx-metadata-jvm is used in R8, this led to quite real issues
where Android Studio would throw exceptions when reading certain
libraries, and thus fail to offer autocompletion or provide navigation
for such libraries.

No test is added because creating such test would require to use
kotlinx-metadata-jvm to serialize a library, and then call cls stub
builder on it, which seems too much hassle. In the future, the code in
this subsystem should not try to replicate the compiler's metadata
reading code anyway, and use kotlinx-metadata-jvm itself, which is far
more reliable and better tested at the moment (see KTIJ-1274).

 #KT-43699 Fixed

<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Issue link: <https://youtrack.jetbrains.com/issue/CHANGE_ME>