### PR TITLE
Support Android single-variant-sync for KAPT

### DIFF
--- a/compiler-plugins/kapt/src/org/jetbrains/kotlin/kapt/idea/KaptProjectResolverExtension.kt
+++ b/compiler-plugins/kapt/src/org/jetbrains/kotlin/kapt/idea/KaptProjectResolverExtension.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.ProjectKeys
 import com.intellij.openapi.externalSystem.model.project.*
+import com.intellij.openapi.util.Key
 import org.gradle.tooling.model.idea.IdeaModule
 import org.jetbrains.kotlin.idea.framework.GRADLE_SYSTEM_ID
 import org.jetbrains.plugins.gradle.model.data.GradleSourceSetData
@@ -31,7 +32,15 @@ class KaptProjectResolverExtension : AbstractProjectResolverExtension() {
         private val LOG = Logger.getInstance(KaptProjectResolverExtension::class.java)
     }
 
-    override fun getExtraProjectModelClasses() = setOf(KaptGradleModel::class.java)
+    override fun getExtraProjectModelClasses(): Set<Class<KaptGradleModel>> {
+        val isAndroidPluginRequestingKotlinGradleModelKey = Key.findKeyByName("IS_ANDROID_PLUGIN_REQUESTING_KAPT_GRADLE_MODEL_KEY")
+        if (isAndroidPluginRequestingKotlinGradleModelKey != null && resolverCtx.getUserData(isAndroidPluginRequestingKotlinGradleModelKey) != null) {
+            return emptySet()
+        }
+
+        return setOf(KaptGradleModel::class.java)
+    }
+
     override fun getToolingExtensionsClasses() = setOf(KaptModelBuilderService::class.java, Unit::class.java)
 
     override fun populateModuleExtraModels(gradleModule: IdeaModule, ideModule: DataNode<ModuleData>) {


### PR DESCRIPTION
ATTN: @zoldater 

This change is a follow up to
https://github.com/JetBrains/kotlin/pull/3888 which introduced Android
single-variant sync support for `KotlinGradleModel`.

Android Gradle projects may have multiple build variants with a little
different sets of sources, however the IDE project reflects only one
android build variant at any time (called selected build variant).

Android Studio/Android IDE plugin does request Android build models
for the currently selected build variant only. It allows to avoid
dependency resolution for other build variants since it is expensive.
However, `KaptModelBuilderService` resolves dependencies for all
Android build variants even though they are not used in the IDE later.

This change makes it possible for Android Studio/Android IDE plugin to
request `KaptGradleModel` on behalf of Kotlin plugin but request
models for the currently selected build variant only. Note, that Android
plugin will request models for Android and non-Android modules when
present.

