### PR TITLE
KT-45153 VariableDeclarationIntoWhenFix: EOL comment after the property to be inlined is removed

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MoveVariableDeclarationIntoWhenInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MoveVariableDeclarationIntoWhenInspection.kt
@@ -109,7 +109,8 @@ private class VariableDeclarationIntoWhenFix(
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val property = descriptor.psiElement as? KtProperty ?: return
         val subjectExpression = subjectExpressionPointer.element ?: return
-        val newElement = transform(property)?.copy() ?: return
+        val newElement = property.copy() as? KtProperty ?: return
+        val toReplace = transform(newElement) ?: return
 
         val lastChild = newElement.lastChild
         if (lastChild is PsiComment && lastChild.node.elementType == KtTokens.EOL_COMMENT) {
@@ -125,7 +126,7 @@ private class VariableDeclarationIntoWhenFix(
             lastChild.delete()
         }
 
-        val resultElement = subjectExpression.replace(newElement)
+        val resultElement = subjectExpression.replace(toReplace)
         property.delete()
 
         val editor = resultElement.findExistingEditor() ?: return

--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6702,6 +6702,11 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment3.kt");
         }
 
+        @TestMetadata("withComment4.kt")
+        public void testWithComment4() throws Exception {
+            runTest("testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment4.kt");
+        }
+
         @TestMetadata("withNewLine.kt")
         public void testWithNewLine() throws Exception {
             runTest("testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withNewLine.kt");

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment4.kt
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment4.kt
@@ -1,0 +1,7 @@
+fun foo(style: Int?) {
+    val a<caret> = style ?: 0 // comment
+    when (a) {
+        0 -> {}
+        else -> {}
+    }
+}

--- a/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment4.kt.after
+++ b/idea/testData/inspectionsLocal/moveVariableDeclarationIntoWhen/withComment4.kt.after
@@ -1,0 +1,6 @@
+fun foo(style: Int?) {
+    when (<caret>style ?: 0) { // comment
+        0 -> {}
+        else -> {}
+    }
+}


### PR DESCRIPTION
Issue link: <https://youtrack.jetbrains.com/issue/KT-45153>

The cause is that when inlining a property, `transformer` returns `property.initializer`, so comments are lost.