### PR TITLE
KTIJ-1245 Do not report "Boolean literal argument without parameter name" for `Pair` and `Triple`

### DIFF
--- a/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -140,6 +140,16 @@ public abstract class LocalInspectionTestGenerated extends AbstractLocalInspecti
             runTest("testData/inspectionsLocal/booleanLiteralArgument/javaMethod.kt");
         }
 
+        @TestMetadata("pair.kt")
+        public void testPair() throws Exception {
+            runTest("testData/inspectionsLocal/booleanLiteralArgument/pair.kt");
+        }
+
+        @TestMetadata("triple.kt")
+        public void testTriple() throws Exception {
+            runTest("testData/inspectionsLocal/booleanLiteralArgument/triple.kt");
+        }
+
         @TestMetadata("vararg.kt")
         public void testVararg() throws Exception {
             runTest("testData/inspectionsLocal/booleanLiteralArgument/vararg.kt");

--- a/idea/testData/inspectionsLocal/booleanLiteralArgument/pair.kt
+++ b/idea/testData/inspectionsLocal/booleanLiteralArgument/pair.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// PROBLEM: none
+fun test() {
+    Pair(true, false<caret>)
+}

--- a/idea/testData/inspectionsLocal/booleanLiteralArgument/triple.kt
+++ b/idea/testData/inspectionsLocal/booleanLiteralArgument/triple.kt
@@ -1,0 +1,5 @@
+// WITH_RUNTIME
+// PROBLEM: none
+fun test() {
+    Triple(true, false, true<caret>)
+}


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-1245