### PR TITLE
KTIJ-3682 Keyword completion should not offer 'constructor' keyword or 'companion object' inside an object declaration

### DIFF
--- a/completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt
+++ b/completion/src/org/jetbrains/kotlin/idea/completion/KeywordCompletion.kt
@@ -29,6 +29,7 @@ import com.intellij.psi.filters.position.LeftNeighbour
 import com.intellij.psi.filters.position.PositionElementFilter
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet
+import com.intellij.psi.util.parentOfType
 import com.intellij.psi.util.parentOfTypes
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.config.LanguageFeature
@@ -420,6 +421,12 @@ object KeywordCompletion {
 
     private fun buildFilterByText(prefixText: String, position: PsiElement): (KtKeywordToken) -> Boolean {
         val psiFactory = KtPsiFactory(position.project)
+
+        fun PsiElement.isSecondaryConstructorInObjectDeclaration(): Boolean {
+            val secondaryConstructor = parentOfType<KtSecondaryConstructor>() ?: return false
+            return secondaryConstructor.getContainingClassOrObject() is KtObjectDeclaration
+        }
+
         fun isKeywordCorrectlyApplied(keywordTokenType: KtKeywordToken, file: KtFile): Boolean {
             val elementAt = file.findElementAt(prefixText.length)!!
 
@@ -438,6 +445,8 @@ object KeywordCompletion {
                 (keywordTokenType == VAL_KEYWORD || keywordTokenType == VAR_KEYWORD) &&
                         elementAt.parent is KtParameter &&
                         elementAt.parentOfTypes(KtNamedFunction::class, KtSecondaryConstructor::class) != null -> return false
+
+                keywordTokenType == CONSTRUCTOR_KEYWORD && elementAt.isSecondaryConstructorInObjectDeclaration() -> return false
 
                 keywordTokenType !is KtModifierKeywordToken -> return true
 

--- a/completion/test/org/jetbrains/kotlin/idea/completion/test/KeywordCompletionTestGenerated.java
+++ b/completion/test/org/jetbrains/kotlin/idea/completion/test/KeywordCompletionTestGenerated.java
@@ -356,6 +356,21 @@ public class KeywordCompletionTestGenerated extends AbstractKeywordCompletionTes
         runTest("testData/keywords/NoCompletionForCapitalPrefix.kt");
     }
 
+    @TestMetadata("NoConstructorInCompanion.kt")
+    public void testNoConstructorInCompanion() throws Exception {
+        runTest("testData/keywords/NoConstructorInCompanion.kt");
+    }
+
+    @TestMetadata("NoConstructorInObject.kt")
+    public void testNoConstructorInObject() throws Exception {
+        runTest("testData/keywords/NoConstructorInObject.kt");
+    }
+
+    @TestMetadata("NoConstructorInObjectLiteral.kt")
+    public void testNoConstructorInObjectLiteral() throws Exception {
+        runTest("testData/keywords/NoConstructorInObjectLiteral.kt");
+    }
+
     @TestMetadata("NoContinue.kt")
     public void testNoContinue() throws Exception {
         runTest("testData/keywords/NoContinue.kt");

--- a/completion/testData/keywords/InObjectScope.kt
+++ b/completion/testData/keywords/InObjectScope.kt
@@ -18,7 +18,6 @@ object Test {
 // EXIST:  interface
 // EXIST:  val
 // EXIST:  var
-// EXIST:  constructor
 // EXIST:  init
 // EXIST:  operator
 // EXIST:  infix

--- a/completion/testData/keywords/NoConstructorInCompanion.kt
+++ b/completion/testData/keywords/NoConstructorInCompanion.kt
@@ -1,0 +1,7 @@
+class C {
+    companion object {
+        constr<caret>
+    }
+}
+
+// NUMBER: 0

--- a/completion/testData/keywords/NoConstructorInObject.kt
+++ b/completion/testData/keywords/NoConstructorInObject.kt
@@ -1,0 +1,5 @@
+object O {
+    constr<caret>
+}
+
+// NUMBER: 0

--- a/completion/testData/keywords/NoConstructorInObjectLiteral.kt
+++ b/completion/testData/keywords/NoConstructorInObjectLiteral.kt
@@ -1,0 +1,7 @@
+class C {
+    val o = object {
+        con<caret>
+    }
+}
+
+// NUMBER: 0


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KTIJ-3682