### PR TITLE
KT-32444: Work around UAST class init deadlock

### DIFF
--- a/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/kinds/KotlinBinaryExpressionWithTypeKinds.kt
+++ b/uast/uast-kotlin/src/org/jetbrains/uast/kotlin/kinds/KotlinBinaryExpressionWithTypeKinds.kt
@@ -19,6 +19,12 @@ package org.jetbrains.uast.kotlin
 import org.jetbrains.uast.UastBinaryExpressionWithTypeKind
 
 object KotlinBinaryExpressionWithTypeKinds {
+    init {
+        // We trigger class initialization for UastBinaryExpressionWithTypeKind early in order to
+        // avoid a class initializer deadlock (https://youtrack.jetbrains.com/issue/KT-32444).
+        UastBinaryExpressionWithTypeKind.INSTANCE_CHECK
+    }
+
     @JvmField
     val NEGATED_INSTANCE_CHECK = UastBinaryExpressionWithTypeKind.InstanceCheck("!is")
 


### PR DESCRIPTION
The deadlock occurs because `UastBinaryExpressionWithTypeKind` has
a static field referencing a subclass. Thus the class initialization
locks for the superclass and the subclass may be acquired in
different orders on different threads.

We can work around this by eagerly initializing
`UastBinaryExpressionWithTypeKind` before its subclasses are referenced.
This is not a clean fix, but the only alternative is to change the
API of `UastBinaryExpressionWithTypeKind` in IntelliJ.

Issue link: https://youtrack.jetbrains.com/issue/KT-32444