### PR TITLE
FIx KTIJ-5115 "Add use-site target" intention: annotation qualifier lost when adding use-site target

### DIFF
--- a/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/intentions/AddAnnotationUseSiteTargetIntention.kt
@@ -143,6 +143,6 @@ private fun KtAnnotationEntry.applicableUseSiteTargets(): List<AnnotationUseSite
 
 fun KtAnnotationEntry.addUseSiteTarget(useSiteTarget: AnnotationUseSiteTarget, project: Project) {
     project.executeWriteCommand(KotlinBundle.message("add.use.site.target")) {
-        replace(KtPsiFactory(this).createAnnotationEntry("@${useSiteTarget.renderName}:$shortName${valueArgumentList?.text ?: ""}"))
+        replace(KtPsiFactory(this).createAnnotationEntry("@${useSiteTarget.renderName}:${text.drop(1)}"))
     }
 }

--- a/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
+++ b/idea/test/org/jetbrains/kotlin/idea/intentions/IntentionTestGenerated.java
@@ -49,6 +49,11 @@ public abstract class IntentionTestGenerated extends AbstractIntentionTest {
             runTest("testData/intentions/addAnnotationUseSiteTarget/hasTarget3.kt");
         }
 
+        @TestMetadata("qualifiedAnnotationDoesNotLoseQualifier.kt")
+        public void testQualifiedAnnotationDoesNotLoseQualifier() throws Exception {
+            runTest("testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.kt");
+        }
+
         @RunWith(JUnit3RunnerWithInners.class)
         @TestMetadata("testData/intentions/addAnnotationUseSiteTarget/constructor")
         public static class Constructor extends AbstractIntentionTest {

--- a/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.1.kt
+++ b/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.1.kt
@@ -1,0 +1,3 @@
+package p
+
+annotation class A

--- a/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.1.kt.after
+++ b/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.1.kt.after
@@ -1,0 +1,3 @@
+package p
+
+annotation class A

--- a/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.kt
+++ b/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.kt
@@ -1,0 +1,6 @@
+// CHOOSE_USE_SITE_TARGET: field
+
+class Test {
+    @p.A<caret>
+    val foo: String = ""
+}

--- a/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.kt.after
+++ b/idea/testData/intentions/addAnnotationUseSiteTarget/qualifiedAnnotationDoesNotLoseQualifier.kt.after
@@ -1,0 +1,6 @@
+// CHOOSE_USE_SITE_TARGET: field
+
+class Test {
+    @field:p.A
+    val foo: String = ""
+}

--- a/j2k/new/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterMultiFileTestGenerated.java
+++ b/j2k/new/test/org/jetbrains/kotlin/nj2k/NewJavaToKotlinConverterMultiFileTestGenerated.java
@@ -26,6 +26,11 @@ public class NewJavaToKotlinConverterMultiFileTestGenerated extends AbstractNewJ
         KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
     }
 
+    @TestMetadata("AnnotationDoesNotLoseImport")
+    public void testAnnotationDoesNotLoseImport() throws Exception {
+        runTest("testData/multiFile/AnnotationDoesNotLoseImport/");
+    }
+
     @TestMetadata("AnnotationWithArrayParameter")
     public void testAnnotationWithArrayParameter() throws Exception {
         runTest("testData/multiFile/AnnotationWithArrayParameter/");

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/Main.java
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/Main.java
@@ -1,0 +1,12 @@
+package test;
+
+import p1.A;
+
+public class Main {
+
+    private final String field;
+
+    public Main(@A String field) {
+        this.field = field;
+    }
+}

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/Main.kt
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/Main.kt
@@ -1,0 +1,5 @@
+package test
+
+import p1.A
+
+class Main(@param:A private val field: String)

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/A.kt
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/A.kt
@@ -1,0 +1,4 @@
+package p1;
+
+annotation class A {
+}

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/A.kt.expected
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/A.kt.expected
@@ -1,0 +1,4 @@
+package p1;
+
+annotation class A {
+}

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/B.kt
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/B.kt
@@ -1,0 +1,4 @@
+package p2;
+
+annotation class A {
+}

--- a/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/B.kt.expected
+++ b/j2k/new/testData/multiFile/AnnotationDoesNotLoseImport/external/B.kt.expected
@@ -1,0 +1,4 @@
+package p2;
+
+annotation class A {
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request! 

Please:
  * Read our contribution guide:
    https://github.com/JetBrains/intellij-kotlin/blob/master/CONTRIBUTING.md
    (Updated 26 Aug 2020).
    We might not be able to merge certain kinds of PRs.
    Please contact us if you’re uncertain.
  * Ensure that changes are close to the HEAD of `master`.
  * Attach a link to the YouTrack issue.
  * Add new tests or change the existing ones if the PR changes the plugin functionality.
  * Write additional information about the change if needed.
-->

Fixes https://youtrack.jetbrains.com/issue/KTIJ-5115

Related to https://github.com/JetBrains/kotlin/pull/4206