### PR TITLE
FIR IDE: Fix KtImplementAsConstructorParameterQuickfix

### DIFF
--- a/fir/src/org/jetbrains/kotlin/idea/core/overrideImplement/KtImplementMembersHandler.kt
+++ b/fir/src/org/jetbrains/kotlin/idea/core/overrideImplement/KtImplementMembersHandler.kt
@@ -88,11 +88,11 @@ internal open class KtImplementMembersHandler : KtGenerateMembersHandler() {
 }
 
 internal class KtImplementMembersQuickfix(private val members: Collection<KtClassMemberInfo>) : KtImplementMembersHandler(),
-    IntentionAction {
+                                                                                                IntentionAction {
     override fun getText() = familyName
     override fun getFamilyName() = KotlinIdeaCoreBundle.message("implement.members.handler.family")
 
-    override fun isAvailable(project: Project, editor: Editor, file: PsiFile) = isValidFor(editor, file)
+    override fun isAvailable(project: Project, editor: Editor, file: PsiFile) = true
 
     override fun collectMembersToGenerate(classOrObject: KtClassOrObject): Collection<KtClassMember> {
         return members.map { createKtClassMember(it, BodyType.FROM_TEMPLATE, false) }
@@ -100,18 +100,12 @@ internal class KtImplementMembersQuickfix(private val members: Collection<KtClas
 }
 
 internal class KtImplementAsConstructorParameterQuickfix(private val members: Collection<KtClassMemberInfo>) : KtImplementMembersHandler(),
-    IntentionAction {
+                                                                                                               IntentionAction {
     override fun getText() = KotlinIdeaCoreBundle.message("action.text.implement.as.constructor.parameters")
 
     override fun getFamilyName() = KotlinIdeaCoreBundle.message("implement.members.handler.family")
 
-    override fun isAvailable(project: Project, editor: Editor, file: PsiFile) = isValidFor(editor, file)
-
-    override fun isValidForClass(classOrObject: KtClassOrObject): Boolean {
-        if (classOrObject !is KtClass || classOrObject is KtEnumEntry || classOrObject.isInterface()) return false
-        // TODO: when MPP support is ready, return false if this class is `actual` and any expect classes have primary constructor.
-        return members.any { it.isProperty }
-    }
+    override fun isAvailable(project: Project, editor: Editor, file: PsiFile) = true
 
     override fun collectMembersToGenerate(classOrObject: KtClassOrObject): Collection<KtClassMember> {
         return members.filter { it.isProperty }.map { createKtClassMember(it, BodyType.FROM_TEMPLATE, true) }
@@ -146,11 +140,16 @@ object MemberNotImplementedQuickfixFactories {
         includeImplementAsConstructorParameterQuickfix: Boolean = true
     ): List<IntentionAction> {
         val unimplementedMembers = getUnimplementedMembers(classWithUnimplementedMembers)
+        if (unimplementedMembers.isEmpty()) return emptyList()
 
         return buildList {
             add(KtImplementMembersQuickfix(unimplementedMembers))
-            if (includeImplementAsConstructorParameterQuickfix) {
-                add(KtImplementAsConstructorParameterQuickfix(unimplementedMembers))
+            if (includeImplementAsConstructorParameterQuickfix && classWithUnimplementedMembers is KtClass && classWithUnimplementedMembers !is KtEnumEntry && !classWithUnimplementedMembers.isInterface()) {
+                // TODO: when MPP support is ready, return false if this class is `actual` and any expect classes have primary constructor.
+                val unimplementedProperties = unimplementedMembers.filter { it.isProperty }
+                if (unimplementedProperties.isNotEmpty()) {
+                    add(KtImplementAsConstructorParameterQuickfix(unimplementedProperties))
+                }
             }
         }
     }


### PR DESCRIPTION
The logic deciding whether this quickfix is avaialble should be moved
inside the provider.
