### PR TITLE
Fix build break after 684ef871ee9710c89a81e036cca0e11bf02f5735

### DIFF
--- a/fir-fe10-binding/src/org/jetbrains/kotlin/idea/fir/fe10/BaseDescriptorsWrappers.kt
+++ b/fir-fe10-binding/src/org/jetbrains/kotlin/idea/fir/fe10/BaseDescriptorsWrappers.kt
@@ -394,7 +394,7 @@ class KtSymbolBasedAnonymousFunctionDescriptor(
     override val ktSymbol: KtAnonymousFunctionSymbol,
     context: FE10BindingContext
 ) : KtSymbolBasedFunctionLikeDescriptor(context), SimpleFunctionDescriptor {
-    override fun getName(): Name = SpecialNames.ANONYMOUS_FUNCTION
+    override fun getName(): Name = SpecialNames.ANONYMOUS
 
     override fun getExtensionReceiverParameter(): ReceiverParameterDescriptor? = getExtensionReceiverParameter(ktSymbol)
     override fun getDispatchReceiverParameter(): ReceiverParameterDescriptor? = null


### PR DESCRIPTION
Broken in https://github.com/JetBrains/kotlin/commit/684ef871ee9710c89a81e036cca0e11bf02f5735